### PR TITLE
Temp files in subdir

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,22 @@ For use with [`broth`](https://github.com/DamonOehlman/broth):
 
 Use with [`smokestack`](https://github.com/hughsk/smokestack) has not yet been investigated...
 
+## Contributing
+
+If you want to patch travis-multirunner, here's what you have to do:
+
+- clone this repo
+- npm install
+- export BROWSER=chrome BVER=stable (or any other combo of your choice).
+  This is required for the next steps.
+- ./setup.sh
+- npm test
+- exit the browser started
+
+Make your patches and test them in the usual fashion, and create a pull
+request. The pull request will run Travis to verify that your patch works
+for all the standard browser combos.
+
 ## Prior Art
 
 None of this would have been possible without the docs and code listed below:

--- a/install-chrome.sh
+++ b/install-chrome.sh
@@ -1,13 +1,19 @@
 #!/usr/bin/env bash
+# Install chrome.
+# Arguments: $1=target URL, $2=target path
+#
+# The script expects to run in the script home dir, and uses
+# the subdir "browser-tmp" as a temporary directory.
+#
 FNAME=`echo $1 | sed -r "s/^.*\/([^\/]*)$/\1/"`
 
 # cleanup any old files (shouldn't happen on travis)
-rm -rf $FNAME
 rm -rf ./browser-tmp
+mkdir ./browser-tmp
 
 # get the files
-wget $1
-dpkg -X $FNAME ./browser-tmp
+(cd ./browser-tmp; wget $1)
+dpkg -X ./browser-tmp/$FNAME ./browser-tmp
 
 # remove the broken link
 rm -rf ./browser-tmp/opt/google/chrome*/google-chrome
@@ -15,3 +21,4 @@ rm -rf ./browser-tmp/opt/google/chrome*/google-chrome
 # make the target directory
 mkdir -p $2
 mv ./browser-tmp/opt/google/chrome*/* $2
+rm -rf ./browser-tmp


### PR DESCRIPTION
This pull request makes the setup scripts download the browser .deb file into a subdirectory that is deleted afterwards, instead of downlading it into the root directory of the distribution.
