### PR TITLE
Move browser binaries and symlinks out of the user's homedir.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ node_modules
 *.tar.bz2
 *.deb
 browser-tmp/
+browsers/

--- a/setup.sh
+++ b/setup.sh
@@ -12,10 +12,11 @@ popd > /dev/null
 TARGET_BROWSER=`$SCRIPTPATH/node_modules/.bin/browser-version $BROWSER $BVER`
 TARGET_URL=`echo $TARGET_BROWSER | cut -d'|' -f4`
 TARGET_VERSION=`echo $TARGET_BROWSER | cut -d'|' -f3`
-TARGET_PATH=~/browsers/$BROWSER/$TARGET_VERSION
+TARGET_PATH=$SCRIPTPATH/browsers/$BROWSER/$TARGET_VERSION
 
 # make the local bin directory and include it in the path
-mkdir -p ~/bin
+BINPATH=./browsers/bin
+mkdir -p $BINPATH
 
 # install if required
 if [ ! -d $TARGET_PATH ]; then
@@ -26,11 +27,11 @@ fi
 # create the symbolic links
 case $BROWSER in
   chrome)
-    ln -sf $TARGET_PATH/chrome ~/bin/chrome-$BVER
-    ~/bin/chrome-$BVER --version
+    ln -sf $TARGET_PATH/chrome $BINPATH/chrome-$BVER
+    $BINPATH/chrome-$BVER --version
     ;;
   firefox)
-    ln -sf $TARGET_PATH/firefox ~/bin/firefox-$BVER
-    ~/bin/firefox-$BVER --version
+    ln -sf $TARGET_PATH/firefox $BINPATH/firefox-$BVER
+    $BINPATH/firefox-$BVER --version
     ;;
 esac

--- a/start-chrome.sh
+++ b/start-chrome.sh
@@ -3,7 +3,7 @@ BVER=${BVER-stable}
 DEBUG_OPTS="--enable-logging --v=1 --vmodule=*third_party/libjingle/*=3,*=0"
 EXTRA_OPTS="--no-sandbox --disable-setuid-sandbox --allow-sandbox-debugging"
 UUID=$(cat /proc/sys/kernel/random/uuid)
-BROWSER_COMMAND=./browser/bin/chrome-$BVER
+BROWSER_COMMAND=./browsers/bin/chrome-$BVER
 SCRIPTPATH=$(dirname "$(readlink -f $0)")
 
 #  --log-level=3 \

--- a/start-chrome.sh
+++ b/start-chrome.sh
@@ -3,7 +3,7 @@ BVER=${BVER-stable}
 DEBUG_OPTS="--enable-logging --v=1 --vmodule=*third_party/libjingle/*=3,*=0"
 EXTRA_OPTS="--no-sandbox --disable-setuid-sandbox --allow-sandbox-debugging"
 UUID=$(cat /proc/sys/kernel/random/uuid)
-BROWSER_COMMAND=~/bin/chrome-$BVER
+BROWSER_COMMAND=./browser/bin/chrome-$BVER
 SCRIPTPATH=$(dirname "$(readlink -f $0)")
 
 #  --log-level=3 \

--- a/start-firefox.sh
+++ b/start-firefox.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 BVER=${BVER-stable}
-FIREFOX_COMMAND=~/bin/firefox-$BVER
+FIREFOX_COMMAND=./browser/bin/firefox-$BVER
 FIREFOX_HOME=$HOME/.mozilla/firefox
 
 # determine the script path

--- a/start-firefox.sh
+++ b/start-firefox.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 BVER=${BVER-stable}
-FIREFOX_COMMAND=./browser/bin/firefox-$BVER
+FIREFOX_COMMAND=./browsers/bin/firefox-$BVER
 FIREFOX_HOME=$HOME/.mozilla/firefox
 
 # determine the script path


### PR DESCRIPTION
This makes the test framework self-contained.

Fixes #3 
