### PR TITLE
add fake device flags

### DIFF
--- a/start-chrome.sh
+++ b/start-chrome.sh
@@ -18,4 +18,6 @@ fi
 $BROWSER_COMMAND --disable-setuid-sandbox \
   --console \
   --user-data-dir=$SCRIPTPATH/profiles/$(UUID)/ \
+  --use-fake-device-for-media-stream \
+  --use-fake-ui-for-media-stream \
   --no-first-run $@

--- a/start-chrome.sh
+++ b/start-chrome.sh
@@ -20,4 +20,5 @@ $BROWSER_COMMAND --disable-setuid-sandbox \
   --user-data-dir=$SCRIPTPATH/profiles/$(UUID)/ \
   --use-fake-device-for-media-stream \
   --use-fake-ui-for-media-stream \
+  --allow-file-access-from-files \
   --no-first-run $@

--- a/start-chrome.sh
+++ b/start-chrome.sh
@@ -21,4 +21,5 @@ $BROWSER_COMMAND --disable-setuid-sandbox \
   --use-fake-device-for-media-stream \
   --use-fake-ui-for-media-stream \
   --allow-file-access-from-files \
+  --no-default-browser-check \
   --no-first-run $@


### PR DESCRIPTION
I _think_ that's a sane default behavior, it allows testing things like attachMediaStream in adapter.js with fake streams at least (cc-ing @alvestrand)
