### PR TITLE
Turn on fake devices in firefox.

### DIFF
--- a/firefox-prefs.js
+++ b/firefox-prefs.js
@@ -13,6 +13,7 @@ user_pref("browser.cache.disk.smart_size.enabled", false);
 user_pref("browser.cache.disk.smart_size.first_run", false);
 user_pref("browser.sessionstore.resume_from_crash", false);
 user_pref("browser.startup.page", 0);
+user_pref("media.navigator.streams.fake", true);
 // user_pref("media.navigator.permission.disabled", true);
 // user_pref("device.storage.enabled", true);
 // user_pref("devtools.debugger.remote-enabled", true);


### PR DESCRIPTION
Inspired by https://github.com/DamonOehlman/travis-multirunner/pull/6, this should turn on fake devices in firefox. My hope is that this will fix https://github.com/webrtc/adapter/issues/50.
