### PR TITLE
Add some basic support for OSX

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "travis-multirunner",
   "bin": {
     "travis-sync": "./bin/travis-sync",
+    "start": "./start.sh",
     "start-chrome": "./start-chrome.sh",
     "start-firefox": "./start-firefox.sh"
   },

--- a/start-chrome.sh
+++ b/start-chrome.sh
@@ -2,22 +2,28 @@
 BVER=${BVER-stable}
 DEBUG_OPTS="--enable-logging --v=1 --vmodule=*third_party/libjingle/*=3,*=0"
 EXTRA_OPTS="--no-sandbox --disable-setuid-sandbox --allow-sandbox-debugging"
-UUID=$(cat /proc/sys/kernel/random/uuid)
-BROWSER_COMMAND=./browsers/bin/chrome-$BVER
-SCRIPTPATH=$(dirname "$(readlink -f $0)")
-
+case $OSTYPE in
+	darwin*) 
+		UUID=$(/usr/bin/uuidgen)
+		SCRIPTPATH=$(dirname "$(greadlink -f $0)")
+	;;
+	*) 
+		UUID=$($(cat /proc/sys/kernel/random/uuid))
+		SCRIPTPATH=$(dirname "$(readlink -f $0)")
+	;;
+esac
+BROWSER_COMMAND=${LOCATION:=./browsers/bin/chrome-$BVER}
 #  --log-level=3 \
 #  --use-fake-device-for-media-stream \
 #  --use-fake-ui-for-media-stream \
-
-if [ ! -e $BROWSER_COMMAND ]; then
+if [ -z "$BROWSER_COMMAND" ]; then
   echo "could not find chrome executable: $BROWSER_COMMAND\n";
   exit 1;
 fi
 
-$BROWSER_COMMAND --disable-setuid-sandbox \
+"$BROWSER_COMMAND" --disable-setuid-sandbox \
   --console \
-  --user-data-dir=$SCRIPTPATH/profiles/$(UUID)/ \
+  --user-data-dir=$SCRIPTPATH/profiles/$UUID/ \
   --use-fake-device-for-media-stream \
   --use-fake-ui-for-media-stream \
   --allow-file-access-from-files \

--- a/start-chrome.sh
+++ b/start-chrome.sh
@@ -16,7 +16,7 @@ BROWSER_COMMAND=${LOCATION:=./browsers/bin/chrome-$BVER}
 #  --log-level=3 \
 #  --use-fake-device-for-media-stream \
 #  --use-fake-ui-for-media-stream \
-if [ -z "$BROWSER_COMMAND" ]; then
+if [ ! -e "$BROWSER_COMMAND" ]; then
   echo "could not find chrome executable: $BROWSER_COMMAND\n";
   exit 1;
 fi

--- a/start.sh
+++ b/start.sh
@@ -1,4 +1,14 @@
 # !/usr/bin/env bash
+launch() {
+	LAUNCHCMD="start-$1"
+	hash "$LAUNCHCMD" &> /dev/null
+	if [ $? -eq 1 ]; then
+		LAUNCHCMD="./start-$1.sh"
+	fi
+	echo $LAUNCHCMD
+	. $LAUNCHCMD
+}
+
 if [ -z $BROWSER ]; then
 	echo "No BROWSER variable specified, defaulting to locally installed Chrome"
 	# Default to Chrome
@@ -6,7 +16,7 @@ if [ -z $BROWSER ]; then
 		darwin*) LOCATION="/Applications/Google Chrome.app/Contents/MacOS/Google Chrome";;
 		linux*) ;;
 	esac
-	. ./start-chrome.sh
+	launch chrome
 else
-	. ./start-$BROWSER.sh
+	launch $BROWSER
 fi

--- a/start.sh
+++ b/start.sh
@@ -1,0 +1,12 @@
+# !/usr/bin/env bash
+if [ -z $BROWSER ]; then
+	echo "No BROWSER variable specified, defaulting to locally installed Chrome"
+	# Default to Chrome
+	case $OSTYPE in
+		darwin*) LOCATION="/Applications/Google Chrome.app/Contents/MacOS/Google Chrome";;
+		linux*) ;;
+	esac
+	. ./start-chrome.sh
+else
+	. ./start-$BROWSER.sh
+fi


### PR DESCRIPTION
Hey @DamonOehlman - This aims to provide a little more support for running tests locally in a similar fashion as they are run on Travis CI, particularly when working on OSX.

Mainly, adds a new `start.sh` script, that offers a default launch point, that then delegates off to the appropriate `start-$BROWSER` script if required, else attempts to open up a Chrome instance installed in the default OS location (only OSX at the moment), to support simpified `npm test` commands. 

Instead of something like `browserify test-latest.js | broth start-$BROWSER | tap-spec`, it would change to `browserify test-latest.js | broth start | tap-spec`. As a result, running `npm test` locally will attempt to spool up your locally installed Chrome instance and run the tests (although Chrome keeps crashing on me when I do - which is a little annoying), but will still support Travis CI passing in the BROWSER variable.

Also modifies the `start-chrome` script to detect if it's on Mac, and to use alternatives to GNU things.
