### PR TITLE
Fixes positional arguments for all environments

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ matrix:
 before_script:
   - ./setup.sh
   - export DISPLAY=:99.0
-  - sh -e /etc/init.d/xvfb start
+  - sh -e /etc/init.d/xvfb start +extension RANDR
 
 after_failure:
   - for file in *.log; do echo $file; echo "======================"; cat $file; done || true

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ matrix:
 before_script:
   - ./setup.sh
   - export DISPLAY=:99.0
-  - sh -e /etc/init.d/xvfb start +extension RANDR
+  - sh -e /etc/init.d/xvfb start
 
 after_failure:
   - for file in *.log; do echo $file; echo "======================"; cat $file; done || true

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "start-firefox": "./start-firefox.sh"
   },
   "scripts": {
-    "test": "testling -x ./start-$BROWSER.sh",
+    "test": "testling -x ./start.sh",
     "postinstall": "./bin/travis-sync"
   },
   "repository": {

--- a/start-chrome.sh
+++ b/start-chrome.sh
@@ -8,7 +8,8 @@ case $OSTYPE in
 		SCRIPTPATH=$(dirname "$(greadlink -f $0)")
 	;;
 	*) 
-		UUID=$($(cat /proc/sys/kernel/random/uuid))
+		echo "Generating UUID for profile..."
+    UUID=$(cat /proc/sys/kernel/random/uuid)
 		SCRIPTPATH=$(dirname "$(readlink -f $0)")
 	;;
 esac
@@ -21,6 +22,7 @@ if [ ! -e "$BROWSER_COMMAND" ]; then
   exit 1;
 fi
 
+echo "Opening $@ in $BROWSER_COMMAND"
 "$BROWSER_COMMAND" --disable-setuid-sandbox \
   --console \
   --user-data-dir=$SCRIPTPATH/profiles/$UUID/ \
@@ -28,4 +30,4 @@ fi
   --use-fake-ui-for-media-stream \
   --allow-file-access-from-files \
   --no-default-browser-check \
-  --no-first-run $@
+  --no-first-run "$@"

--- a/start-chrome.sh
+++ b/start-chrome.sh
@@ -9,7 +9,7 @@ case $OSTYPE in
 	;;
 	*) 
 		echo "Generating UUID for profile..."
-    UUID=$(cat /proc/sys/kernel/random/uuid)
+		UUID=$(cat /proc/sys/kernel/random/uuid)
 		SCRIPTPATH=$(dirname "$(readlink -f $0)")
 	;;
 esac

--- a/start.sh
+++ b/start.sh
@@ -1,13 +1,9 @@
 # !/usr/bin/env bash
-PARAMS=$@
-launch() {
-	LAUNCHCMD="start-$1"
-	hash "$LAUNCHCMD" &> /dev/null
-	if [ $? -eq 1 ]; then
-		LAUNCHCMD="./start-$1.sh"
-	fi
-	. $LAUNCHCMD $PARAMS
-}
+echo "Starting Travis CI multiple browser runner"
+echo "-----------"
+echo "Parameters:"
+echo "$@"
+echo "-----------"
 
 if [ -z $BROWSER ]; then
 	echo "No BROWSER variable specified, defaulting to locally installed Chrome"
@@ -16,7 +12,24 @@ if [ -z $BROWSER ]; then
 		darwin*) LOCATION="/Applications/Google Chrome.app/Contents/MacOS/Google Chrome";;
 		linux*) ;;
 	esac
-	launch chrome
+	TARGET="chrome"
 else
-	launch $BROWSER
+	TARGET=$BROWSER
 fi
+
+# Execute the appropriate script
+LAUNCHCMD="start-$TARGET"
+# Check if the launch command is accessible
+hash "$LAUNCHCMD" 2>/dev/null
+if [ $? -eq 1 ]; then
+	LAUNCHCMD="./start-$TARGET.sh"
+fi
+# Exit if we can't find the launch command
+hash "$LAUNCHCMD" 2>/dev/null
+if [ $? -eq 1 ]; then
+	echo "Could not find launch command! [${LAUNCHCMD}]"
+	exit 1;
+fi
+
+echo "Launching ${LAUNCHCMD}..."
+. "$LAUNCHCMD" "$@"


### PR DESCRIPTION
The launch function in start was causing all sorts of problems with the passing through of positional arguments - worked fine on Mac, failed horribly on Linux and Travis CI and caused all sorts of issues.

After trying various permutations trying to make the function work, it has now been relegated to the scrap heap...
