### PR TITLE
Another alternative to shell scripts

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -9,9 +9,14 @@ SCRIPTPATH=`pwd -P`
 popd > /dev/null
 
 # get the browser version string
-TARGET_BROWSER=`$SCRIPTPATH/node_modules/.bin/browser-version $BROWSER $BVER`
-TARGET_URL=`echo $TARGET_BROWSER | cut -d'|' -f4`
-TARGET_VERSION=`echo $TARGET_BROWSER | cut -d'|' -f3`
+case $OSTYPE in
+  darwin*) PLATFORM="mac";;
+  linux*) PLATFORM="linux";;
+esac
+
+TARGET_BROWSER=`curl -H 'Accept: text/csv' http://browsers.contralis.info/$PLATFORM/$BROWSER/$BVER`
+TARGET_URL=`echo $TARGET_BROWSER | cut -d',' -f7`
+TARGET_VERSION=`echo $TARGET_BROWSER | cut -d',' -f5`
 TARGET_PATH=$SCRIPTPATH/browsers/$BROWSER/$TARGET_VERSION
 
 # make the local bin directory and include it in the path
@@ -20,7 +25,7 @@ mkdir -p $BINPATH
 
 # install if required
 if [ ! -d $TARGET_PATH ]; then
-  echo "getting $BROWSER $TARGET_VERSION"
+  echo "getting $BROWSER $TARGET_VERSION from $TARGET_URL"
   source $SCRIPTPATH/install-$BROWSER.sh "$TARGET_URL" "$TARGET_PATH"
 fi
 


### PR DESCRIPTION
As an alternative to `browser-version` and `browser-sleuth`, uses browsers.contralis.info (an API on top of browser-sleuth) to provide a nice, curlable, standardized interface for accessing browser version information, without the hassle of trying to deal with all the conditions in bash.

Does have the downside of relying on browsers.contralis.info now however, though it's a pretty lightweight service so it's no skin off my nose running it. Plus, with a little bit of work, I figure it can track all browser version histories and provide easy links to all of them - which might be useful.

Thoughts @DamonOehlman? No problems if you decide to keep with the pure "do everything in bash" approach though. I'm just looking for something so I can get my tests passing on Firefox again :)
