### PR TITLE
ignore microsoft edge

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -2,6 +2,9 @@
 set -x
 set -e
 
+if [ $BROWSER == "MicrosoftEdge" ]; then
+  exit 0
+fi
 # determine the script path
 # ref: http://stackoverflow.com/questions/4774054/reliable-way-for-a-bash-script-to-get-the-full-path-to-itself
 pushd `dirname $0` > /dev/null


### PR DESCRIPTION
this ignores Microsofts Edge browser in setup.sh.

Typically we run travis-multirunner on linux where you can't run or install Edge. But we may still be using a matrix attribute with BROWSER=MicrosoftEdge to remotely control Edge using selenium. See https://github.com/webrtc/adapter/pull/258 for the long story behind this.
