### PR TITLE
install-firefox: clean up directory

### DIFF
--- a/install-firefox.sh
+++ b/install-firefox.sh
@@ -13,3 +13,4 @@ tar xvf $FNAME --directory ./browser-tmp
 # # make the target directory
 mkdir -p $2
 mv ./browser-tmp/firefox/* $2
+rm -rf ./browser-tmp


### PR DESCRIPTION
cleans up the browser-tmp directory after installing firefox.

Similar to what is done for Chrome.