### PR TITLE
Fixed postinstall on Windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "scripts": {
     "test": "testling -x ./start.sh",
-    "postinstall": "./bin/travis-sync"
+    "postinstall": "node bin/travis-sync"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Changed the postinstall job to use node explicitly to run
the travis-sync script.
Fixes #15