### PR TITLE
Safari updates

### DIFF
--- a/install-safari.sh
+++ b/install-safari.sh
@@ -1,5 +1,8 @@
 #!/usr/bin/env bash
 
+# Install Safari or Safari Technology Preview
+# Arguments: $1=target URL
+
 # Download and install Safari Tech Preview
 if [ $BVER == "unstable" ] && [ ! -f "/Applications/Safari Technology Preview.app/Contents/MacOS/Safari Technology Preview" ]; then
   curl -L $1 > SDP.dmg
@@ -39,6 +42,7 @@ defaults write com.apple.$SAFARI_SHORT_NAME com.apple.Safari.ContentPageGroupIde
 
 # Allow insecure domains
 defaults write com.apple.$SAFARI_SHORT_NAME WebKitMediaCaptureRequiresSecureConnection 0
+defaults write com.apple.$SAFARI_SHORT_NAME com.apple.Safari.ContentPageGroupIdentifier.WebKit2MediaCaptureRequiresSecureConnection 0
 
 # Turn on Allow Remote Automation. This only works in Mac OS 10.13+
 MAC_OS_VERSION=`defaults read loginwindow SystemVersionStampAsString`

--- a/install-safari.sh
+++ b/install-safari.sh
@@ -25,6 +25,11 @@ else
   SAFARI_SHORT_NAME="Safari"
 fi
 
+# Launch and kill Safari so that we can start to override the settings
+open -a "$SAFARI_NAME"
+sleep 2
+killall "$SAFARI_NAME"
+
 # Tell Safari not to restore the browser windows when it is relaunched
 defaults write com.apple.$SAFARI_SHORT_NAME ApplePersistenceIgnoreState YES
 
@@ -41,6 +46,12 @@ if [[ $MAC_OS_VERSION =~ ^10\.1[3-9]\..+ ]]; then
   sudo safaridriver --enable
 fi
 
+# determine the script path
+# ref: http://stackoverflow.com/questions/4774054/reliable-way-for-a-bash-script-to-get-the-full-path-to-itself
+pushd `dirname $0` > /dev/null
+SCRIPTPATH=`pwd -P`
+popd > /dev/null
+
 # Allow device access
 # This UserMediaPermissions.plist file allows 127.0.0.1 and localhost. To add other domains
 # you need to run Safari Technology Preview on your system, visit the domain you want to allow
@@ -48,13 +59,4 @@ fi
 # then click on the red camera in the URL bar and choose "Always Allow".
 # Finally copy the `~/Library/SafariTechnologyPreview/UserMediaPermissions.plist` file into the
 # same directory on Travis.
-open -a "$SAFARI_NAME"
-sleep 2
-killall "$SAFARI_NAME"
-
-# determine the script path
-# ref: http://stackoverflow.com/questions/4774054/reliable-way-for-a-bash-script-to-get-the-full-path-to-itself
-pushd `dirname $0` > /dev/null
-SCRIPTPATH=`pwd -P`
-popd > /dev/null
 cp $SCRIPTPATH/UserMediaPermissions.plist ~/Library/$SAFARI_SHORT_NAME/

--- a/install-safari.sh
+++ b/install-safari.sh
@@ -16,3 +16,36 @@ if [ ! -z $TRAVIS ]; then
   hdiutil attach Soundflower.dmg
   sudo installer -pkg /Volumes/Soundflower-2.0b2/Soundflower.pkg -target /
 fi
+
+if [ $BVER == "unstable" ]; then
+  SAFARI_NAME="Safari Technology Preview"
+  SAFARI_SHORT_NAME="SafariTechnologyPreview"
+else
+  SAFARI_NAME="Safari"
+  SAFARI_SHORT_NAME="Safari"
+fi
+
+# Tell Safari not to restore the browser windows when it is relaunched
+defaults write com.apple.$SAFARI_SHORT_NAME ApplePersistenceIgnoreState YES
+
+# Turn on fake devices
+defaults write com.apple.$SAFARI_SHORT_NAME WebKitMockCaptureDevicesEnabled 1
+defaults write com.apple.$SAFARI_SHORT_NAME com.apple.Safari.ContentPageGroupIdentifier.WebKit2MockCaptureDevicesEnabled 1
+
+# Allow insecure domains
+defaults write com.apple.$SAFARI_SHORT_NAME WebKitMediaCaptureRequiresSecureConnection 0
+
+# Turn on Allow Remote Automation. This only works in Mac OS 10.13+
+sudo safaridriver --enable
+
+# Allow device access
+# This UserMediaPermissions.plist file allows 127.0.0.1 and localhost. To add other domains
+# you need to run Safari Technology Preview on your system, visit the domain you want to allow
+# and call navigator.mediaDevices.getUserMedia. When prompted allow access to devices allow access
+# then click on the red camera in the URL bar and choose "Always Allow".
+# Finally copy the `~/Library/SafariTechnologyPreview/UserMediaPermissions.plist` file into the
+# same directory on Travis.
+open -a "$SAFARI_NAME"
+sleep 2
+killall "$SAFARI_NAME"
+cp ./UserMediaPermissions.plist ~/Library/$SAFARI_SHORT_NAME/

--- a/install-safari.sh
+++ b/install-safari.sh
@@ -51,4 +51,10 @@ fi
 open -a "$SAFARI_NAME"
 sleep 2
 killall "$SAFARI_NAME"
-cp ./UserMediaPermissions.plist ~/Library/$SAFARI_SHORT_NAME/
+
+# determine the script path
+# ref: http://stackoverflow.com/questions/4774054/reliable-way-for-a-bash-script-to-get-the-full-path-to-itself
+pushd `dirname $0` > /dev/null
+SCRIPTPATH=`pwd -P`
+popd > /dev/null
+cp $SCRIPTPATH/UserMediaPermissions.plist ~/Library/$SAFARI_SHORT_NAME/

--- a/install-safari.sh
+++ b/install-safari.sh
@@ -36,7 +36,10 @@ defaults write com.apple.$SAFARI_SHORT_NAME com.apple.Safari.ContentPageGroupIde
 defaults write com.apple.$SAFARI_SHORT_NAME WebKitMediaCaptureRequiresSecureConnection 0
 
 # Turn on Allow Remote Automation. This only works in Mac OS 10.13+
-sudo safaridriver --enable
+MAC_OS_VERSION=`defaults read loginwindow SystemVersionStampAsString`
+if [[ $MAC_OS_VERSION =~ ^10\.1[3-9]\..+ ]]; then
+  sudo safaridriver --enable
+fi
 
 # Allow device access
 # This UserMediaPermissions.plist file allows 127.0.0.1 and localhost. To add other domains

--- a/start-safari.sh
+++ b/start-safari.sh
@@ -1,34 +1,7 @@
+#!/usr/bin/env bash
+
 if [ $BVER == "unstable" ]; then
-  SAFARI_NAME="Safari Technology Preview"
-  SAFARI_SHORT_NAME="SafariTechnologyPreview"
+  open -a "Safari Technology Preview" $@
 else
-  SAFARI_NAME="Safari"
-  SAFARI_SHORT_NAME="Safari"
+  open -a "Safari" $@
 fi
-
-# Tell Safari not to restore the browser windows when it is relaunched
-defaults write com.apple.$SAFARI_SHORT_NAME ApplePersistenceIgnoreState YES
-
-# Turn on fake devices
-defaults write com.apple.$SAFARI_SHORT_NAME WebKitMockCaptureDevicesEnabled 1
-defaults write com.apple.$SAFARI_SHORT_NAME com.apple.Safari.ContentPageGroupIdentifier.WebKit2MockCaptureDevicesEnabled 1
-
-# Allow insecure domains
-defaults write com.apple.$SAFARI_SHORT_NAME WebKitMediaCaptureRequiresSecureConnection 0
-
-# Turn on Allow Remote Automation. This only works in Mac OS 10.13+
-sudo safaridriver --enable
-
-# Allow device access
-# This UserMediaPermissions.plist file allows 127.0.0.1 and localhost. To add other domains
-# you need to run Safari Technology Preview on your system, visit the domain you want to allow
-# and call navigator.mediaDevices.getUserMedia. When prompted allow access to devices allow access
-# then click on the red camera in the URL bar and choose "Always Allow".
-# Finally copy the `~/Library/SafariTechnologyPreview/UserMediaPermissions.plist` file into the
-# same directory on Travis.
-open -a "$SAFARI_NAME"
-sleep 2
-killall "$SAFARI_NAME"
-cp ./UserMediaPermissions.plist ~/Library/$SAFARI_SHORT_NAME/
-
-open -a "$SAFARI_NAME" $@

--- a/start-safari.sh
+++ b/start-safari.sh
@@ -16,6 +16,9 @@ defaults write com.apple.$SAFARI_SHORT_NAME com.apple.Safari.ContentPageGroupIde
 # Allow insecure domains
 defaults write com.apple.$SAFARI_SHORT_NAME WebKitMediaCaptureRequiresSecureConnection 0
 
+# Turn on Allow Remote Automation. This only works in Mac OS 10.13+
+sudo safaridriver --enable
+
 # Allow device access
 # This UserMediaPermissions.plist file allows 127.0.0.1 and localhost. To add other domains
 # you need to run Safari Technology Preview on your system, visit the domain you want to allow


### PR DESCRIPTION
Adding a few changes that I needed to get tests working for opentok.
https://github.com/aullman/opentok-test-scripts/pull/11

* Turning on allow remote automation in Mac OS 10.13+ (unfortunately we can't test this right now because Travis doesn't offer it yet).
* Moved the Safari settings into the 'install-safari.sh' script because they don't need to run every time for Safari, just once and not all test frameworks use the start-BROWSER.sh scripts.
* Correct the path to UserMediaPermissions.plist.
* Set allow insecure domains properly.