### PR TITLE
Use sed to get the Safari Technology Preview version

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -32,8 +32,8 @@ elif [ $BROWSER == "safari" ] && [ $BVER == "unstable" ]; then
   # This is quite dangerous, it is scraping the safari download website for the URL. If the format
   # of the website changes then it won't work anymore. We should add safari to
   # browsers.contralis.info instead
-  TARGET_URL=`curl https://developer.apple.com/safari/download/ | grep https://secure-appldnld.apple.com | grep "macOS 10.12" | cut -d'"' -f6`
-  TARGET_VERSION="33"
+  TARGET_URL=`curl https://developer.apple.com/safari/download/ | sed -nE 's/.*href="(.*\.dmg)">.*macOS 10.12.*/\1/p'`
+  TARGET_VERSION=`curl https://developer.apple.com/safari/download/ | sed -nE 's/.*>([0-9]+)<\/p>.*$/\1/p'`
 else
   TARGET_BROWSER=`curl -H 'Accept: text/csv' http://browsers.contralis.info/$PLATFORM/$BROWSER/$BVER`
   TARGET_URL=`echo $TARGET_BROWSER | cut -d',' -f7`


### PR DESCRIPTION
Also using sed to get the URL in a bit of a safer way. Looking for .dmg hrefs on the page with "macOS 10.12" mentioned.

Before the version was just hardcoded as 33 but now we're up to 35. So I'm pulling in the actual version from the download page so that it shows up in the log like so: https://travis-ci.org/aullman/travis-multirunner/jobs/253080937#L295