### PR TITLE
Use xcode9 image

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,11 +35,11 @@ matrix:
       env: BROWSER=firefox BVER=46.0.1
     - os: osx
       sudo: required
-      osx_image: xcode8.3
+      osx_image: xcode9
       env: BROWSER=safari BVER=stable
     - os: osx
       sudo: required
-      osx_image: xcode8.3
+      osx_image: xcode9
       env: BROWSER=safari BVER=unstable
 
   fast_finish: true

--- a/template.yaml
+++ b/template.yaml
@@ -28,11 +28,11 @@ matrix:
       env: BROWSER=firefox BVER=unstable
     - os: osx
       sudo: required
-      osx_image: xcode8.3
+      osx_image: xcode9
       env: BROWSER=safari BVER=stable
     - os: osx
       sudo: required
-      osx_image: xcode8.3
+      osx_image: xcode9
       env: BROWSER=safari BVER=unstable
 
   fast_finish: true


### PR DESCRIPTION
The latest Safari Tech Preview needs Mac OS 10.12.6 and the xcode8.3 image is still on 10.12.5.