### PR TITLE
install scripts: make wget quiet

### DIFF
--- a/install-chrome.sh
+++ b/install-chrome.sh
@@ -12,7 +12,7 @@ rm -rf ./browser-tmp
 mkdir ./browser-tmp
 
 # get the files
-(cd ./browser-tmp; wget $1)
+(cd ./browser-tmp; wget -q $1)
 dpkg -X ./browser-tmp/$FNAME ./browser-tmp
 
 # remove the broken link

--- a/install-firefox.sh
+++ b/install-firefox.sh
@@ -7,7 +7,7 @@ rm -rf ./browser-tmp
 mkdir -p ./browser-tmp
 
 # get the files
-wget $1
+wget -q $1
 tar xvf $FNAME --directory ./browser-tmp
 
 # # make the target directory


### PR DESCRIPTION
uses -q to make the wget output less verbose and remove the progress indicator
which makes the CI logs hard to read