### PR TITLE
setup: exit early when bver is not set

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -5,6 +5,9 @@ set -e
 if [ $BROWSER == "MicrosoftEdge" ]; then
   exit 0
 fi
+if [ -z $BVER ]; then
+  exit 0
+fi
 # determine the script path
 # ref: http://stackoverflow.com/questions/4774054/reliable-way-for-a-bash-script-to-get-the-full-path-to-itself
 pushd `dirname $0` > /dev/null


### PR DESCRIPTION
useful on CI servers where you might not want download firefox
for a test that does not use Firefox.