### PR TITLE
setup: ignore electron, nw and android

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -5,6 +5,15 @@ set -e
 if [ $BROWSER == "MicrosoftEdge" ]; then
   exit 0
 fi
+if [ $BROWSER == "Electron" ]; then
+  exit 0
+fi
+if [ $BROWSER == "NodeWebkit" ]; then
+  exit 0
+fi
+if [ $BVER == "android" ]; then
+  exit 0
+fi
 if [ -z $BVER ]; then
   exit 0
 fi


### PR DESCRIPTION
adds the option to install electron via npm