### PR TITLE
Replace browsers.contralis.info

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -47,7 +47,7 @@ elif [ $BROWSER == "safari" ] && [ $BVER == "unstable" ]; then
   TARGET_URL=`curl https://developer.apple.com/safari/download/ | sed -nE 's/.*href="(.*\.dmg)">.*macOS 10.12.*/\1/p'`
   TARGET_VERSION=`curl https://developer.apple.com/safari/download/ | sed -nE 's/.*>([0-9]+)<\/p>.*$/\1/p'`
 else
-  TARGET_BROWSER=`curl -H 'Accept: text/csv' http://browsers.contralis.info/$PLATFORM/$BROWSER/$BVER`
+  TARGET_BROWSER=`curl -H 'Accept: text/csv' https://browser-version-api.herokuapp.com/$PLATFORM/$BROWSER/$BVER`
   TARGET_URL=`echo $TARGET_BROWSER | cut -d',' -f7`
   TARGET_VERSION=`echo $TARGET_BROWSER | cut -d',' -f5`
 fi


### PR DESCRIPTION
Addresses #34.

This replaces http://browsers.contralis.info with https://browser-version-api.herokuapp.com - same service as it's always been, just with 100% less potential for DNS failure (assuming of course that Heroku is better at paying renewals).