### PR TITLE
Fix safari tech preview

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,7 +35,7 @@ matrix:
       env: BROWSER=firefox BVER=46.0.1
     - os: osx
       sudo: required
-      osx_image: xcode9.4
+      osx_image: xcode9.2
       env: BROWSER=safari BVER=stable
     - os: osx
       sudo: required

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,7 +39,7 @@ matrix:
       env: BROWSER=safari BVER=stable
     - os: osx
       sudo: required
-      osx_image: xcode9.4
+      osx_image: xcode11.2
       env: BROWSER=safari BVER=unstable
 
   fast_finish: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,11 +35,11 @@ matrix:
       env: BROWSER=firefox BVER=46.0.1
     - os: osx
       sudo: required
-      osx_image: xcode9
+      osx_image: xcode9.4
       env: BROWSER=safari BVER=stable
     - os: osx
       sudo: required
-      osx_image: xcode9
+      osx_image: xcode9.4
       env: BROWSER=safari BVER=unstable
 
   fast_finish: true

--- a/install-safari.sh
+++ b/install-safari.sh
@@ -11,15 +11,6 @@ if [ $BVER == "unstable" ] && [ ! -f "/Applications/Safari Technology Preview.ap
 fi
 # Safari stable is already installed, no need to do anything
 
-# If we're running on Travis
-if [ ! -z $TRAVIS ]; then
-  # Download and install Soundflower to get audio output devices otherwise we get crashes
-  # https://bugs.webkit.org/show_bug.cgi?id=172794
-  curl -L https://github.com/mattingalls/Soundflower/releases/download/2.0b2/Soundflower-2.0b2.dmg > Soundflower.dmg
-  hdiutil attach Soundflower.dmg
-  sudo installer -pkg /Volumes/Soundflower-2.0b2/Soundflower.pkg -target /
-fi
-
 if [ $BVER == "unstable" ]; then
   SAFARI_NAME="Safari Technology Preview"
   SAFARI_SHORT_NAME="SafariTechnologyPreview"

--- a/install-safari.sh
+++ b/install-safari.sh
@@ -11,6 +11,15 @@ if [ $BVER == "unstable" ] && [ ! -f "/Applications/Safari Technology Preview.ap
 fi
 # Safari stable is already installed, no need to do anything
 
+# If we're running on Travis
+if [ ! -z $TRAVIS ]; then
+  # Download and install Soundflower to get audio output devices otherwise we get crashes
+  # https://bugs.webkit.org/show_bug.cgi?id=172794
+  curl -L https://github.com/mattingalls/Soundflower/releases/download/2.0b2/Soundflower-2.0b2.dmg > Soundflower.dmg
+  hdiutil attach Soundflower.dmg
+  sudo installer -pkg /Volumes/Soundflower-2.0b2/Soundflower.pkg -target /
+fi
+
 if [ $BVER == "unstable" ]; then
   SAFARI_NAME="Safari Technology Preview"
   SAFARI_SHORT_NAME="SafariTechnologyPreview"

--- a/install-safari.sh
+++ b/install-safari.sh
@@ -30,6 +30,7 @@ defaults write com.apple.$SAFARI_SHORT_NAME ApplePersistenceIgnoreState YES
 # Turn on fake devices
 defaults write com.apple.$SAFARI_SHORT_NAME WebKitMockCaptureDevicesEnabled 1
 defaults write com.apple.$SAFARI_SHORT_NAME com.apple.Safari.ContentPageGroupIdentifier.WebKit2MockCaptureDevicesEnabled 1
+defaults write com.apple.$SAFARI_SHORT_NAME WebKitPreferences.mockCaptureDevicesEnabled 1
 
 # Allow insecure domains
 defaults write com.apple.$SAFARI_SHORT_NAME WebKitMediaCaptureRequiresSecureConnection 0

--- a/install-safari.sh
+++ b/install-safari.sh
@@ -12,7 +12,7 @@ fi
 # Safari stable is already installed, no need to do anything
 
 # If we're running on Travis
-if [ ! -z $TRAVIS ]; then
+if [ ! -z $TRAVIS ] && [ $BVER == "stable" ]; then
   # Download and install Soundflower to get audio output devices otherwise we get crashes
   # https://bugs.webkit.org/show_bug.cgi?id=172794
   curl -L https://github.com/mattingalls/Soundflower/releases/download/2.0b2/Soundflower-2.0b2.dmg > Soundflower.dmg

--- a/setup.sh
+++ b/setup.sh
@@ -44,7 +44,7 @@ elif [ $BROWSER == "safari" ] && [ $BVER == "unstable" ]; then
   # This is quite dangerous, it is scraping the safari download website for the URL. If the format
   # of the website changes then it won't work anymore. We should add safari to
   # browsers.contralis.info instead
-  TARGET_URL=`curl https://developer.apple.com/safari/download/ | sed -nE 's/.*href="(.*\.dmg)">.*macOS 10.13.*/\1/p'`
+  TARGET_URL=`curl https://developer.apple.com/safari/download/ | sed -nE 's/.*href="(.*\.dmg)">.*macOS 10.14.*/\1/p'`
   TARGET_VERSION=`curl https://developer.apple.com/safari/download/ | sed -nE 's/.*>([0-9]+)<\/p>.*$/\1/p'`
 else
   TARGET_BROWSER=`curl -H 'Accept: text/csv' https://browser-version-api.herokuapp.com/$PLATFORM/$BROWSER/$BVER`

--- a/setup.sh
+++ b/setup.sh
@@ -44,7 +44,7 @@ elif [ $BROWSER == "safari" ] && [ $BVER == "unstable" ]; then
   # This is quite dangerous, it is scraping the safari download website for the URL. If the format
   # of the website changes then it won't work anymore. We should add safari to
   # browsers.contralis.info instead
-  TARGET_URL=`curl https://developer.apple.com/safari/download/ | sed -nE 's/.*href="(.*\.dmg)">.*macOS 10.12.*/\1/p'`
+  TARGET_URL=`curl https://developer.apple.com/safari/download/ | sed -nE 's/.*href="(.*\.dmg)">.*macOS 10.13.*/\1/p'`
   TARGET_VERSION=`curl https://developer.apple.com/safari/download/ | sed -nE 's/.*>([0-9]+)<\/p>.*$/\1/p'`
 else
   TARGET_BROWSER=`curl -H 'Accept: text/csv' https://browser-version-api.herokuapp.com/$PLATFORM/$BROWSER/$BVER`

--- a/template.yaml
+++ b/template.yaml
@@ -32,7 +32,7 @@ matrix:
       env: BROWSER=safari BVER=stable
     - os: osx
       sudo: required
-      osx_image: xcode9.4
+      osx_image: xcode11.2
       env: BROWSER=safari BVER=unstable
 
   fast_finish: true

--- a/template.yaml
+++ b/template.yaml
@@ -28,11 +28,11 @@ matrix:
       env: BROWSER=firefox BVER=unstable
     - os: osx
       sudo: required
-      osx_image: xcode9
+      osx_image: xcode9.4
       env: BROWSER=safari BVER=stable
     - os: osx
       sudo: required
-      osx_image: xcode9
+      osx_image: xcode9.4
       env: BROWSER=safari BVER=unstable
 
   fast_finish: true


### PR DESCRIPTION
Get Safari Tech Preview working again. It now needs Mac OS 10.13 and also has yet another way to turn on fake media devices.