### PR TITLE
add helper script to find a matching chromedriver version

### DIFF
--- a/chromedriver_version.sh
+++ b/chromedriver_version.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -x
+set -e
+
+BINPATH=./browsers/bin
+VERSION=`$BINPATH/chrome-$BVER --version | awk '{print $3}'`
+MAJOR=`$BINPATH/chrome-$BVER --version | awk '{print $3}' | awk -F '.' '{print $1}'`
+
+# http://chromedriver.chromium.org/downloads/version-selection
+CHROMEDRIVER_VERSION=$(curl -f https://chromedriver.storage.googleapis.com/LATEST_RELEASE_${VERSION} \
+ || curl -f https://chromedriver.storage.googleapis.com/LATEST_RELEASE_${MAJOR} \
+ || curl -f https://chromedriver.storage.googleapis.com/LATEST_RELEASE_$((MAJOR - 1)))
+
+echo $CHROMEDRIVER_VERSION


### PR DESCRIPTION
Adds a helper script to help figure out the latest available version of chromedriver
which can then be fed into CHROMEDRIVER_VERSION as described on
  https://github.com/giggio/node-chromedriver#versioning