### PR TITLE
Add OSVER environment variable

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -41,10 +41,12 @@ if [[ $BVER =~ $VERSION_REGEX ]] ; then
  fi
  TARGET_VERSION=$BVER
 elif [ $BROWSER == "safari" ] && [ $BVER == "unstable" ]; then
+  OSVER="${OSVER:-10.14}"
+
   # This is quite dangerous, it is scraping the safari download website for the URL. If the format
   # of the website changes then it won't work anymore. We should add safari to
   # browsers.contralis.info instead
-  TARGET_URL=`curl https://developer.apple.com/safari/download/ | sed -nE 's/.*href="(.*\.dmg)">.*macOS 10.14.*/\1/p'`
+  TARGET_URL=`curl https://developer.apple.com/safari/download/ | sed -nE "s/.*href="(.*\.dmg)">.*macOS $OSVER.*/\1/p"`
   TARGET_VERSION=`curl https://developer.apple.com/safari/download/ | sed -nE 's/.*>([0-9]+)<\/p>.*$/\1/p'`
 else
   TARGET_BROWSER=`curl -H 'Accept: text/csv' https://browser-version-api.herokuapp.com/$PLATFORM/$BROWSER/$BVER`

--- a/setup.sh
+++ b/setup.sh
@@ -46,7 +46,7 @@ elif [ $BROWSER == "safari" ] && [ $BVER == "unstable" ]; then
   # This is quite dangerous, it is scraping the safari download website for the URL. If the format
   # of the website changes then it won't work anymore. We should add safari to
   # browsers.contralis.info instead
-  TARGET_URL=`curl https://developer.apple.com/safari/download/ | sed -nE "s/.*href="(.*\.dmg)">.*macOS $OSVER.*/\1/p"`
+  TARGET_URL=`curl https://developer.apple.com/safari/download/ | sed -nE "s/.*href=\"(.*\.dmg)\">.*macOS $OSVER.*/\1/p"`
   TARGET_VERSION=`curl https://developer.apple.com/safari/download/ | sed -nE 's/.*>([0-9]+)<\/p>.*$/\1/p'`
 else
   TARGET_BROWSER=`curl -H 'Accept: text/csv' https://browser-version-api.herokuapp.com/$PLATFORM/$BROWSER/$BVER`


### PR DESCRIPTION
Adds OSVER environment variable, which lets user specify which OS version the user wants to target.

For example, macOS users may want to download the Catalina (macOS 10.15.x) version of Safari, instead of the Mojave version