### PR TITLE
add github action

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,18 @@ For use with [`broth`](https://github.com/DamonOehlman/broth):
 
 Use with [`smokestack`](https://github.com/hughsk/smokestack) has not yet been investigated...
 
+## Github action
+This package includes a github action. It will export the browser binary
+path and can be used as follows:
+```
+    - id: travis-multirunner
+      uses: fippo/multirunner-action@0.2
+      with:
+        browser: chrome
+        version: stable
+    - run: ${{steps.travis-multirunner.outputs.path}} --version
+```
+
 ## Contributing
 
 If you want to patch travis-multirunner, here's what you have to do:

--- a/action.yml
+++ b/action.yml
@@ -1,0 +1,22 @@
+name: 'travis-multirunner'
+description: 'Installs a browser using travis-multirunner'
+inputs:
+  browser:
+    description: 'What browser to install'
+    default: 'chrome'
+  version:
+    description: 'What version of the browser to install'
+    default: 'stable'
+outputs:
+  path:
+    description: 'browser binary path'
+    value: ${{steps.setup.outputs.path}}
+runs:
+  using: 'composite'
+  steps: 
+    - id: setup
+      run: ${{github.action_path}}/setup.sh
+      shell: bash
+      env:
+        BROWSER: ${{inputs.browser}}
+        BVER: ${{inputs.version}}

--- a/setup.sh
+++ b/setup.sh
@@ -83,3 +83,7 @@ case $BROWSER in
     fi
     ;;
 esac
+
+# set output path for github action
+echo ::set-output name=path::$TARGET_PATH/$BROWSER
+


### PR DESCRIPTION
I fancy actions these days but still like travis-multirunner :-)

the `uses` is obviously work in progress, WIP runs (in adapter for simplicity) [here](https://github.com/webrtcHacks/adapter/pull/1060) and wip-repo [here](https://github.com/fippo/multirunner-action)