### PR TITLE
updated dependency for normalize-package-info

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,6 @@
   "dependencies": {
     "djo-shell": "^1.0.0",
     "formatter": "^0.4.1",
-    "normalize-package-data": "^2.3.8"
+    "normalize-package-data": "^5.0.0"
   }
 }


### PR DESCRIPTION
Mend/Whitesource is showing `travis-multirunner` security vulnerabilities with these dependencies:
- `path-parse` @ 1.0.6 [Link](https://www.mend.io/vulnerability-database/CVE-2021-23343)
- `hosted-git-info` @ 2.8.8 [Link](https://www.mend.io/vulnerability-database/CVE-2021-23362)

Updating `normalize-package-data`:
- removes dependency for `resolve` which carries the `path-parse` vulnerability.
- upgrades `hosted-git-info` to 6.0.0, which eliminates vulnerability present in 2.8.8